### PR TITLE
Add GPS sensor parsing tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/stormpod/sensors/sensor_gps.py
+++ b/stormpod/sensors/sensor_gps.py
@@ -15,11 +15,12 @@ class GPSSensor:
     def _parse_latlon(self, raw, direction):
         if not raw or raw == "0":
             return None
-        deg = int(raw[:2])
-        minutes = float(raw[2:])
+        deg_len = len(raw.split(".")[0]) - 2
+        deg = int(raw[:deg_len])
+        minutes = float(raw[deg_len:])
         coord = deg + minutes / 60.0
         return coord if direction in ["N", "E"] else -coord
-    
+
     def _parse_line(self, line):
         if line.startswith("$GPRMC") or line.startswith("$GNRMC"):
             parts = line.split(",")
@@ -29,11 +30,11 @@ class GPSSensor:
                 self.latest["lon"] = self._parse_latlon(parts[5], parts[6])
                 self.latest["speed_kph"] = round(float(parts[7]) * 1.852, 2)
                 self.latest["time_utc"] = parts[1][:6]
-            try:
-                heading = float(parts[8])
-                self.latest["heading_deg"] = heading
-            except:
-                self.latest["heading_deg"] = None
+                try:
+                    heading = float(parts[8])
+                    self.latest["heading_deg"] = heading
+                except:
+                    self.latest["heading_deg"] = None
             else:
                 self.latest["fix"] = False
 

--- a/tests/test_sensor_gps.py
+++ b/tests/test_sensor_gps.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from stormpod.sensors.sensor_gps import GPSSensor
+
+
+def _gps_sensor():
+    gps = GPSSensor.__new__(GPSSensor)
+    gps.latest = {
+        "lat": None,
+        "lon": None,
+        "fix": False,
+        "speed_kph": 0.0,
+        "time_utc": None,
+    }
+    return gps
+
+
+def test_parse_line_with_fix():
+    gps = _gps_sensor()
+    line = "$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A"
+    gps._parse_line(line)
+    assert gps.latest["fix"] is True
+    assert gps.latest["lat"] == pytest.approx(48.1173, abs=1e-4)
+    assert gps.latest["lon"] == pytest.approx(11.516666, abs=1e-4)
+    assert gps.latest["speed_kph"] == pytest.approx(41.48)
+    assert gps.latest["time_utc"] == "123519"
+    assert gps.latest["heading_deg"] == pytest.approx(84.4)
+
+
+def test_parse_line_without_fix():
+    gps = _gps_sensor()
+    line = "$GPRMC,123519,V,,,,,,,230394,,,N*53"
+    gps._parse_line(line)
+    assert gps.latest["fix"] is False
+    assert gps.latest["lat"] is None
+    assert gps.latest["lon"] is None
+    assert "heading_deg" not in gps.latest


### PR DESCRIPTION
## Summary
- add unit tests for GPS sensor parsing
- fix GPS parser coordinate logic and fix handling
- run tests in CI via GitHub Actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a571241ce0832591098469a971a580